### PR TITLE
Add mobile preview toggle

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -52,6 +52,8 @@ const App = () => {
     // Visibility states for search and filter UI controlled by Header buttons
     const [showSearchBar, setShowSearchBar] = useState(false);
     const [showFilters, setShowFilters] = useState(false);
+    const [mobilePreview, setMobilePreview] = useState(false);
+    const toggleMobilePreview = () => setMobilePreview(v => !v);
 
     useEffect(() => {
         localStorage.setItem('language', language);
@@ -296,7 +298,7 @@ const App = () => {
     }
     
  return (
-  <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 text-gray-100 font-sans antialiased pt-12">
+ <div className={`min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 text-gray-100 font-sans antialiased pt-12 ${mobilePreview ? 'mobile-preview' : ''}`}> 
     {/* Enhanced Header */}
     <Header
       showHeader={showHeader}
@@ -310,6 +312,8 @@ const App = () => {
       creditsBalance={creditsBalance}
       language={language}
       setLanguage={setLanguage}
+      mobilePreview={mobilePreview}
+      toggleMobilePreview={toggleMobilePreview}
       GoogleIcon={GoogleIcon}
     />
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Award, Search, Filter, LogOut } from 'lucide-react';
+import { Award, Search, Filter, LogOut, Smartphone } from 'lucide-react';
 
 const Header = ({
   showHeader,
@@ -13,6 +13,8 @@ const Header = ({
   creditsBalance,
   language,
   setLanguage,
+  mobilePreview,
+  toggleMobilePreview,
   GoogleIcon,
 }) => (
   <header
@@ -69,6 +71,13 @@ const Header = ({
         <span className="text-xs text-gray-400 ml-1">{creditsBalance}</span>
         <button onClick={() => setLanguage(language === 'en' ? 'th' : 'en')} className="px-2 py-1 rounded-lg bg-gray-800 text-gray-100 text-xs ml-1">
           {language === 'en' ? '🇹🇭' : '🇬🇧'}
+        </button>
+        <button
+          onClick={toggleMobilePreview}
+          className={`p-1 text-gray-400 hover:text-gray-100 hover:bg-gray-800/50 rounded-lg ml-1 ${mobilePreview ? 'text-blue-400' : ''}`}
+          title="Mobile preview"
+        >
+          <Smartphone size={14} />
         </button>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,10 @@ body {
   @apply m-0 bg-gray-950 text-gray-100 font-sans;
   font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
 }
+.mobile-preview {
+  max-width: 375px;
+  margin: 0 auto;
+  border: 4px solid #333;
+  border-radius: 1rem;
+  overflow: hidden;
+}


### PR DESCRIPTION
## Summary
- allow toggling of mobile preview
- expose toggle button in the header
- style `.mobile-preview` container

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855935a65d08329a27d2b5b0efe1f7b