### PR TITLE
Refine mobile preview layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Search, Star, Camera, CheckCircle, User, TrendingUp, Calendar, Filter, Plus, X, ChevronDown, LogOut, Sparkles, MapPin, Globe, Heart, MessageCircle, Award, Clock, ArrowLeft } from 'lucide-react';
+import { Search, Star, Camera, CheckCircle, User, TrendingUp, Calendar, Filter, Plus, X, ChevronDown, LogOut, Sparkles, MapPin, Globe, Heart, MessageCircle, Award, Clock, ArrowLeft, Monitor } from 'lucide-react';
 import { initialSampleReviews } from './data/sampleReviews';
 import Header from './components/Header';
 import ItemList from './components/ItemList';
@@ -52,6 +52,8 @@ const App = () => {
     // Visibility states for search and filter UI controlled by Header buttons
     const [showSearchBar, setShowSearchBar] = useState(false);
     const [showFilters, setShowFilters] = useState(false);
+    const [mobilePreview, setMobilePreview] = useState(false);
+    const toggleMobilePreview = () => setMobilePreview(v => !v);
 
     useEffect(() => {
         localStorage.setItem('language', language);
@@ -295,8 +297,18 @@ const App = () => {
         );
     }
     
- return (
-  <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 text-gray-100 font-sans antialiased pt-12">
+  return (
+  <div className={`min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 text-gray-100 font-sans antialiased pt-14 px-2 sm:px-6 transition-all duration-200 ${mobilePreview ? 'mobile-preview' : ''}`}>
+    {mobilePreview && (
+      <button
+        onClick={toggleMobilePreview}
+        className="fixed top-2 right-2 z-30 bg-blue-600 text-white p-2 rounded-full shadow-lg hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+        title="Desktop view"
+        aria-label="Exit mobile preview and return to desktop view"
+      >
+        <Monitor size={20} />
+      </button>
+    )}
     {/* Enhanced Header */}
     <Header
       showHeader={showHeader}
@@ -310,6 +322,8 @@ const App = () => {
       creditsBalance={creditsBalance}
       language={language}
       setLanguage={setLanguage}
+      mobilePreview={mobilePreview}
+      toggleMobilePreview={toggleMobilePreview}
       GoogleIcon={GoogleIcon}
     />
 

--- a/src/components/CompactReviewCard.jsx
+++ b/src/components/CompactReviewCard.jsx
@@ -8,7 +8,7 @@ const CompactReviewCard = ({ item, onDetails, language = 'en' }) => {
   const avatarLetter = review ? review.author.charAt(0).toUpperCase() : '';
 
   return (
-    <div className="compact-review-card">
+    <div className="compact-review-card item-list-card">
       <div className="crc-header">
         <h3 className="crc-title">{language === 'th' && item.itemName_th ? item.itemName_th : item.itemName}</h3>
       </div>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Award, Search, Filter, LogOut } from 'lucide-react';
+import { Award, Search, Filter, LogOut, Smartphone } from 'lucide-react';
 
 const Header = ({
   showHeader,
@@ -13,16 +13,15 @@ const Header = ({
   creditsBalance,
   language,
   setLanguage,
+  mobilePreview,
+  toggleMobilePreview,
   GoogleIcon,
 }) => (
   <header
-    className={`relative bg-gray-900/90 backdrop-blur-xl border-b border-gray-800/50 fixed top-0 w-full z-20 transition-transform duration-300 ${showHeader ? 'translate-y-0' : '-translate-y-full'}`}
-    style={{ minHeight: '32px', padding: '0.15rem 0' }}
+    className={`header relative bg-gray-900/90 backdrop-blur-xl border-b border-gray-800/50 fixed top-0 w-full z-20 transition-transform duration-300 ${showHeader ? 'translate-y-0' : '-translate-y-full'}`}
+    style={{ minHeight: '48px', padding: '0.3rem 0' }}
   >
-    <div className="absolute top-0 left-1 text-[10px] text-gray-400 pointer-events-none">
-      version 2.5
-    </div>
-    <div className="max-w-4xl mx-auto flex items-center justify-between px-3 py-0.5 gap-2">
+    <div className="max-w-4xl mx-auto flex items-center justify-between px-3 py-1 gap-2">
       <div className="flex items-center gap-2">
         <div className="w-6 h-6 bg-gradient-to-br from-purple-600 to-blue-600 rounded-lg flex items-center justify-center">
           <Award className="text-white" size={16} />
@@ -69,6 +68,14 @@ const Header = ({
         <span className="text-xs text-gray-400 ml-1">{creditsBalance}</span>
         <button onClick={() => setLanguage(language === 'en' ? 'th' : 'en')} className="px-2 py-1 rounded-lg bg-gray-800 text-gray-100 text-xs ml-1">
           {language === 'en' ? '🇹🇭' : '🇬🇧'}
+        </button>
+        <button
+          onClick={toggleMobilePreview}
+          className={`p-2 text-gray-400 hover:text-blue-500 hover:bg-gray-800 rounded-lg ml-1 border-2 border-blue-400 ${mobilePreview ? 'bg-blue-950 text-blue-300' : ''}`}
+          title={mobilePreview ? 'Switch to Desktop View' : 'Switch to Mobile View'}
+          aria-label={mobilePreview ? 'Switch to Desktop View' : 'Switch to Mobile View'}
+        >
+          <Smartphone size={20} />
         </button>
       </div>
     </div>

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -20,7 +20,7 @@ const ItemList = ({
   const [showImages, setShowImages] = useState(false);
 
   return (
-    <main className="max-w-7xl mx-auto px-4 py-8">
+    <main className="main-content px-1 py-4 sm:max-w-7xl sm:mx-auto sm:px-4 sm:py-8">
       <div className="flex justify-end mb-2">
         <button
           type="button"
@@ -41,25 +41,27 @@ const ItemList = ({
         ) : filteredReviews.length > 0 ? (
           filteredReviews.map((item) =>
             showImages ? (
-              <ReviewItem
-                key={item.id}
-                generateImage={generateImage}
-                item={item}
-                onClick={handleItemClick}
-                language={language}
-                categories={categories}
-                citiesData={citiesData}
-                bangkokStreetsData={bangkokStreetsData}
-                generatedImages={generatedImages}
-                setGeneratedImages={setGeneratedImages}
-              />
+              <div key={item.id} className="item-list-card">
+                <ReviewItem
+                  generateImage={generateImage}
+                  item={item}
+                  onClick={handleItemClick}
+                  language={language}
+                  categories={categories}
+                  citiesData={citiesData}
+                  bangkokStreetsData={bangkokStreetsData}
+                  generatedImages={generatedImages}
+                  setGeneratedImages={setGeneratedImages}
+                />
+              </div>
             ) : (
-              <CompactReviewCard
-                key={item.id}
-                item={item}
-                onDetails={handleItemClick}
-                language={language}
-              />
+              <div key={item.id} className="item-list-card">
+                <CompactReviewCard
+                  item={item}
+                  onDetails={handleItemClick}
+                  language={language}
+                />
+              </div>
             )
           )
         ) : (

--- a/src/components/ReviewItem.js
+++ b/src/components/ReviewItem.js
@@ -104,7 +104,7 @@ const ReviewItem = ({
 
     return (
         <div
-            className={`relative bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 rounded-2xl shadow-lg border border-gray-700/50 p-2 cursor-pointer transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl hover:border-gray-600/50 max-w-[18rem] w-full mx-auto ${isHovered ? 'ring-2 ring-purple-500/20' : ''}`}
+            className={`item-list-card relative bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 rounded-2xl shadow-lg border border-gray-700/50 p-2 cursor-pointer transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl hover:border-gray-600/50 max-w-[18rem] w-full mx-auto ${isHovered ? 'ring-2 ring-purple-500/20' : ''}`}
             onClick={() => onClick(item)}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,50 @@ body {
   @apply m-0 bg-gray-950 text-gray-100 font-sans;
   font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
 }
+.mobile-preview {
+  max-width: 390px;
+  margin: 0 auto;
+  border: 4px solid #222;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  box-shadow: 0 0 40px 0 #000a;
+  background: #18181b;
+}
+
+/* Make all buttons touch-friendly in mobile preview */
+.mobile-preview button,
+.mobile-preview input,
+.mobile-preview select {
+  min-height: 48px;
+  font-size: 1.1rem;
+  border-radius: 0.75rem;
+  touch-action: manipulation;
+}
+
+.mobile-preview .card,
+.mobile-preview .item-list-card {
+  background: #23272f;
+  border-radius: 1rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 2px 16px 0 #0004;
+  padding: 1.25rem 1rem;
+  width: 100%;
+  max-width: none;
+}
+
+.mobile-preview .header {
+  padding: 1rem 1.5rem;
+}
+
+/* Force single-column layout in mobile preview */
+.mobile-preview .grid {
+  grid-template-columns: 1fr !important;
+}
+
+/* Improve spacing for all content in mobile preview */
+.mobile-preview .content,
+.mobile-preview .main-content {
+  max-width: 100% !important;
+  margin: 0 !important;
+  padding: 0.75rem 0.5rem;
+}


### PR DESCRIPTION
## Summary
- adjust `ItemList` container to use full width on mobile
- keep device frame styling and card layout
- ensure full width content in mobile preview

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6855935a65d08329a27d2b5b0efe1f7b